### PR TITLE
Reworked tcp helpers

### DIFF
--- a/transforms.py
+++ b/transforms.py
@@ -48,7 +48,7 @@ def _quaternion_from_euler(ai, aj, ak):
 
 def _quaternion_multiply(q0, q1):
     """
-    Multiplies two quaternions.
+    Multiplies two quaternions. Convention used [qx, qy, qz, qw]
 
     Input
     :param q0: A 4 element array containing the first quaternion (q01, q11, q21, q31)
@@ -59,16 +59,16 @@ def _quaternion_multiply(q0, q1):
 
     """
     # Extract the values from q0
-    w0 = q0[0]
-    x0 = q0[1]
-    y0 = q0[2]
-    z0 = q0[3]
+    x0 = q0[0]
+    y0 = q0[1]
+    z0 = q0[2]
+    w0 = q0[3]
 
     # Extract the values from q1
-    w1 = q1[0]
-    x1 = q1[1]
-    y1 = q1[2]
-    z1 = q1[3]
+    x1 = q1[0]
+    y1 = q1[1]
+    z1 = q1[2]
+    w1 = q1[3]
 
     # Computer the product of the two quaternions, term by term
     q0q1_w = w0 * w1 - x0 * x1 - y0 * y1 - z0 * z1
@@ -77,7 +77,7 @@ def _quaternion_multiply(q0, q1):
     q0q1_z = w0 * z1 + x0 * y1 - y0 * x1 + z0 * w1
 
     # Create a 4 element array containing the final quaternion
-    final_quaternion = numpy.array([q0q1_w, q0q1_x, q0q1_y, q0q1_z])
+    final_quaternion = numpy.array([q0q1_x, q0q1_y, q0q1_z, q0q1_w])
 
     # Return a 4 element array containing the final quaternion (q02,q12,q22,q32)
     return final_quaternion

--- a/transforms.py
+++ b/transforms.py
@@ -23,6 +23,7 @@ from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
 
 def _quaternion_from_euler(ai, aj, ak):
+    # quaternion order is [qx, qy, qz, qw]
     ai /= 2.0
     aj /= 2.0
     ak /= 2.0
@@ -110,15 +111,15 @@ class TCPTransforms:
         pose_target_frame = tf2_geometry_msgs.do_transform_pose(pose_source_frame, transform)
 
         if rotation:
-            # Rotate for 180° about Y
-            q_rot = _quaternion_from_euler(0, 0, math.pi)
+            # Rotate for 180° about local Y
+            q_rot = _quaternion_from_euler(0, math.pi, 0)
             q_in = numpy.empty((4, ))
             q_in[0] = pose_target_frame.orientation.x
             q_in[1] = pose_target_frame.orientation.y
             q_in[2] = pose_target_frame.orientation.z
             q_in[3] = pose_target_frame.orientation.w
 
-            q_in = _quaternion_multiply(q_rot, q_in)
+            q_in = _quaternion_multiply(q_in, q_rot)
 
             # Made the gripper look down
             pose_target_frame.orientation.x = q_in[0]


### PR DESCRIPTION
Fixed transformation functions and made the TCP functions more generic.

Instead of hard-coding an optional rotation of the gripper link, define 2 frames to lookup and optionally add a tool offset to the `source_frame` that matches the TF transforms between a `tcp_link_name` and a `tool_link_name` frame.

`pose_source_frame` is always where the `tool_link` shuld be moved to, OR where the `tcp_link` should be moved to when `apply_tool_offset` is False, both represented in `source_frame`
the output is always where `tcp_link` will be moved to represented in `target_frame`

with a correct `tool_link` setup in the URDF or provided live with a broadcaster, the `tcp_link` will be computed correctly for any virtual `tool_link` as long as there is a transform to it.
