### PR TITLE
Add vector3 transform util function

### DIFF
--- a/transforms.py
+++ b/transforms.py
@@ -21,6 +21,10 @@ import tf2_geometry_msgs
 from tf2_ros import TransformException
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
+<<<<<<< Updated upstream
+=======
+from geometry_msgs.msg import Vector3, Vector3Stamped, Pose
+>>>>>>> Stashed changes
 
 def _quaternion_from_euler(ai, aj, ak):
     # quaternion order is [qx, qy, qz, qw]
@@ -156,3 +160,12 @@ class TCPTransforms:
         pose_target_frame = tf2_geometry_msgs.do_transform_pose(tcp_pose_source_frame, src_tgt_transform)
 
         return pose_target_frame
+    
+    def to_from_tcp_vec3_conversion(self, vec3_source_frame: Vector3Stamped, source_frame: str, target_frame: str) -> Vector3:
+        """Apply tf transformation to a vector3"""
+        src_tgt_transform = self.tf_buffer.lookup_transform(target_frame, source_frame, rclpy.time.Time())
+
+        vec3_target_frame = tf2_geometry_msgs.do_transform_vector3(vec3_source_frame ,src_tgt_transform)
+
+        return vec3_target_frame.vector
+

--- a/transforms.py
+++ b/transforms.py
@@ -21,10 +21,7 @@ import tf2_geometry_msgs
 from tf2_ros import TransformException
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
-<<<<<<< Updated upstream
-=======
 from geometry_msgs.msg import Vector3, Vector3Stamped, Pose
->>>>>>> Stashed changes
 
 def _quaternion_from_euler(ai, aj, ak):
     # quaternion order is [qx, qy, qz, qw]

--- a/transforms.py
+++ b/transforms.py
@@ -165,4 +165,3 @@ class TCPTransforms:
         vec3_target_frame = tf2_geometry_msgs.do_transform_vector3(vec3_source_frame ,src_tgt_transform)
 
         return vec3_target_frame.vector
-


### PR DESCRIPTION
This PR another util function which can be used for transforming vector3(stamped) messages into another frame. It is added to the transformer class, as it already has access to the tf2 transform buffer.